### PR TITLE
Handle a conflict during copy

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -7,7 +7,7 @@ import sys
 
 from argparse import ArgumentParser
 
-from binstar_client import NotFound
+from binstar_client import NotFound, Conflict
 from binstar_client.utils import get_server_api
 
 
@@ -42,8 +42,12 @@ def sync(from_channel, to_channel, package, token, exact_version=None,
         if exact_version is not None and version != exact_version:
             continue
         print(' -> copying {0} from {1} [{2}] to {3} [{4}]...'.format(basename, from_channel, from_label, to_channel, to_label))
-        api.copy(from_channel, package, version, basename=basename,
-                 to_owner=to_channel, from_label=from_label, to_label=to_label)
+        try:
+            api.copy(from_channel, package, version, basename=basename,
+                     to_owner=to_channel, from_label=from_label, to_label=to_label)
+        except Conflict:
+            # Really this should never happen, but it does.
+            print('    *** Copy failed because of conflict on destination ***')
 
 
 def main(*argv):


### PR DESCRIPTION
Not sure how there can ever be a conflict, but am guessing the index is corrupted on the
astropy channel. 

This works around this case by handling the exception raised if the package exists on the destination.

ping @astrofrog and this fixes https://github.com/astropy/conda-channel-astropy/issues/174